### PR TITLE
Use yamux to mux an existing client connection into a server

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,48 +3,25 @@
 
 [[projects]]
   name = "github.com/golang/protobuf"
-  packages = [
-    "proto",
-    "ptypes",
-    "ptypes/any",
-    "ptypes/duration",
-    "ptypes/timestamp"
-  ]
+  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  name = "github.com/hashicorp/yamux"
+  packages = ["."]
+  revision = "3520598351bb3500a49ae9563f5539666ae0a27c"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/net"
-  packages = [
-    "context",
-    "http/httpguts",
-    "http2",
-    "http2/hpack",
-    "idna",
-    "internal/timeseries",
-    "trace"
-  ]
+  packages = ["context","http/httpguts","http2","http2/hpack","idna","internal/timeseries","trace"]
   revision = "2491c5de3490fced2f6cff376127c667efeed857"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = [
-    "collate",
-    "collate/build",
-    "internal/colltab",
-    "internal/gen",
-    "internal/tag",
-    "internal/triegen",
-    "internal/ucd",
-    "language",
-    "secure/bidirule",
-    "transform",
-    "unicode/bidi",
-    "unicode/cldr",
-    "unicode/norm",
-    "unicode/rangetable"
-  ]
+  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
@@ -56,38 +33,13 @@
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [
-    ".",
-    "balancer",
-    "balancer/base",
-    "balancer/roundrobin",
-    "channelz",
-    "codes",
-    "connectivity",
-    "credentials",
-    "encoding",
-    "encoding/proto",
-    "grpclb/grpc_lb_v1/messages",
-    "grpclog",
-    "internal",
-    "keepalive",
-    "metadata",
-    "naming",
-    "peer",
-    "resolver",
-    "resolver/dns",
-    "resolver/passthrough",
-    "stats",
-    "status",
-    "tap",
-    "transport"
-  ]
+  packages = [".","balancer","balancer/base","balancer/roundrobin","channelz","codes","connectivity","credentials","encoding","encoding/proto","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
   revision = "41344da2231b913fa3d983840a57a6b1b7b631a1"
   version = "v1.12.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cfd176e2c2fdb19b1b7d65561d481d472cf8ae6e78d784f81d48806f2d2f4918"
+  inputs-digest = "27d9679a8fa6373c8d3169435fa252d482a1eb4c8e8e2b3b0b268042cc86a763"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/server/main.go
+++ b/server/main.go
@@ -26,20 +26,20 @@ func main() {
 	}
 	defer ln.Close()
 
-	log.Println("waiting for incoming TCP connections...")
-	// Accept blocks until there is an incoming TCP connection
-	incoming, err := ln.Accept()
-	if err != nil {
-		log.Fatalf("couldn't accept %s", err)
-	}
-
-	incomingConn, err := yamux.Client(incoming, yamux.DefaultConfig())
-	if err != nil {
-		log.Fatalf("couldn't create yamux %s", err)
-	}
-
-	log.Println("starting a gRPC server over incoming TCP connection")
 	for {
+		log.Println("waiting for incoming TCP connections...")
+		// Accept blocks until there is an incoming TCP connection
+		incoming, err := ln.Accept()
+		if err != nil {
+			log.Fatalf("couldn't accept %s", err)
+		}
+
+		incomingConn, err := yamux.Client(incoming, yamux.DefaultConfig())
+		if err != nil {
+			log.Fatalf("couldn't create yamux %s", err)
+		}
+
+		log.Println("starting a gRPC server over incoming TCP connection")
 
 		var conn *grpc.ClientConn
 		// gRPC dial over incoming net.Conn
@@ -55,7 +55,6 @@ func main() {
 
 		// handle connection in goroutine so we can accept new TCP connections
 		go handleConn(conn)
-		time.Sleep(3 * time.Second)
 	}
 }
 


### PR DESCRIPTION
This change reuses a client connection and multiplexes it into a server connection using the `yamux` pkg.